### PR TITLE
remove the branch protection for all dev branches

### DIFF
--- a/otterdog/eclipse-mnestix.jsonnet
+++ b/otterdog/eclipse-mnestix.jsonnet
@@ -36,10 +36,6 @@ orgs.newOrg('dt.mnestix', 'eclipse-mnestix') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 2,
         },
-        orgs.newBranchProtectionRule('dev') {
-          required_approving_review_count: 2,
-          allows_force_pushes: true
-        },
       ],
       topics+: [
         'asset-administration-shell',
@@ -65,10 +61,6 @@ orgs.newOrg('dt.mnestix', 'eclipse-mnestix') {
       branch_protection_rules+: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 2,
-        },
-        orgs.newBranchProtectionRule('dev') {
-          required_approving_review_count: 2,
-          allows_force_pushes: true
         },
       ],
       topics+: [


### PR DESCRIPTION
We have a problem with commits by an ex colleague. To be able to merge dev again, we need to rebase and rebuild the dev branch on top of main.