### PR TITLE
Remove wildcard branch protection rule

### DIFF
--- a/otterdog/eclipse-mnestix.jsonnet
+++ b/otterdog/eclipse-mnestix.jsonnet
@@ -36,12 +36,11 @@ orgs.newOrg('dt.mnestix', 'eclipse-mnestix') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 2,
           allows_deletions: false,
+          requires_conversation_resolution: true,
         },        
         orgs.newBranchProtectionRule('dev') {
           allows_force_pushes: true,
           allows_deletions: false,
-        },
-        orgs.newBranchProtectionRule('**/**') {
           requires_conversation_resolution: true,
         },
       ],
@@ -70,12 +69,11 @@ orgs.newOrg('dt.mnestix', 'eclipse-mnestix') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 2,
           allows_deletions: false,
+          requires_conversation_resolution: true,
         },        
         orgs.newBranchProtectionRule('dev') {
           allows_force_pushes: true,
           allows_deletions: false,
-        },
-        orgs.newBranchProtectionRule('**/**') {
           requires_conversation_resolution: true,
         },
       ],


### PR DESCRIPTION
Wildcard branch protection rule also enforced that you could not directly push to feature branches anymore. 

Sorry for that, that was my mistake.
I changed it to only apply to main and dev